### PR TITLE
Add start/stop tracker controls

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ plotly
 pywin32
 requests
 wmi
+psutil


### PR DESCRIPTION
## Summary
- add psutil to requirements
- add tracker control helper functions
- fix truncated Label Editor strings
- allow starting/stopping the tracker from the Streamlit sidebar

## Testing
- `python3 -m py_compile focus_monitor_dashboard.py`