### PR TITLE
Remove unused plt import

### DIFF
--- a/focus_monitor_dashboard.py
+++ b/focus_monitor_dashboard.py
@@ -1,7 +1,6 @@
 import streamlit as st
 import pandas as pd
 import json
-import matplotlib.pyplot as plt
 import plotly.graph_objects as go
 import plotly.express as px
 import re


### PR DESCRIPTION
## Summary
- remove matplotlib.pyplot import from dashboard script

## Testing
- `python -m py_compile focus_monitor_dashboard.py`